### PR TITLE
Update Readme's Requirements with more links and OS-specific info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,41 @@ prevents collisions with data on your own computer, and the VM can easily be
 destroyed to reclaim disk space once experimentation with the data is complete.
  
 ## Requirements
-You will need to have [Vagrant](https://www.vagrantup.com/downloads.html) and
-[VirtualBox](https://www.virtualbox.org/wiki/Downloads) installed. It is
+You will need to have [Vagrant][1] and [VirtualBox][2] installed. It is
 recommended to update to the latest versions if they are already installed.
+
+The installation instructions also make use of Python's [pip][3] and Python
+virtual environments using [virtualenv][4] and [virtualenvwrapper][5].
+
+### Windows Users
 Ansible is used to provision the Vagrant VM, and since Windows machines
-~~cannot currently~~ can be Ansible controllers
-[with some work](http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/)
-this ~~will not~~ should also work on Windows. A Unix machine (e.g. Linux,
-Mac OS X) is preferred.
+<strike>cannot currently</strike> can be Ansible controllers [with some
+work][6] this <strike>will not</strike> should also work on Windows. A Unix
+machine (e.g. Linux, Mac OS X) is preferred since Ansible will be automatically
+installed into a virtualenv later and will work out of the box on Unix machines.
+
+### Ubuntu Users
+
+On Ubuntu, if you are using the standard Terminal you can quickly get all
+your requirements and set up virtualenvwrapper with:
+
+```bash
+sudo apt-get update
+sudo apt-get install python-pip python-dev build-essential virtualenv virtualenvwrapper vagrant virtualbox
+sudo apt-get install --upgrade pip
+# Set up virtualenvwrapper
+printf '\n%s\n%s\n%s' '# virtualenv' 'export WORKON_HOME=~/virtualenvs' \
+'source /usr/local/bin/virtualenvwrapper.sh' >> ~/.bashrc
+source ~/.bashrc
+mkdir -p $WORKON_HOME
+```
+
+[1]: (https://www.vagrantup.com/downloads.html)
+[2]: (https://www.virtualbox.org/wiki/Downloads)
+[3]: (https://pip.pypa.io/en/stable/installing/)
+[4]: (http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+[5]: (http://virtualenvwrapper.readthedocs.org/en/latest/install.html)
+[6]: (http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/)
 
 System Requirements: 3GB RAM and 90GB Free HD Space.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ prevents collisions with data on your own computer, and the VM can easily be
 destroyed to reclaim disk space once experimentation with the data is complete.
  
 ## Requirements
+
+System Requirements: 3GB RAM and 90GB Free HD Space.
+
 You will need to have [Vagrant][1] and [VirtualBox][2] installed. It is
 recommended to update to the latest versions if they are already installed.
 
@@ -43,8 +46,6 @@ mkdir -p $WORKON_HOME
 [4]: http://docs.python-guide.org/en/latest/dev/virtualenvs/
 [5]: http://virtualenvwrapper.readthedocs.org/en/latest/install.html
 [6]: http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/
-
-System Requirements: 3GB RAM and 90GB Free HD Space.
 
 ## VM Provisioning (a.k.a. Installation)
 Clone the repo and create a virtualenv using the supplied `requirements.txt`. 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ quickly get all your requirements and set up virtualenvwrapper with:
 
 ```bash
 sudo apt-get update
-sudo apt-get install --upgrade python-pip python-dev build-essential  virtualbox libpq-dev
+sudo apt-get install --upgrade python-pip python-dev build-essential virtualbox libpq-dev
 sudo pip install --upgrade pip virtualenv virtualenvwrapper
 # Download latest version of Vagrant (apt-get installs old version)
 wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ quickly get all your requirements and set up virtualenvwrapper with:
 sudo apt-get update
 sudo apt-get install --upgrade python-pip python-dev build-essential virtualbox libpq-dev
 sudo pip install --upgrade pip virtualenv virtualenvwrapper
+# Generate SSH key (for Vagrant to have SSH access to VM)
+mkdir -p $HOME/.ssh
+chmod 0700 $HOME/.ssh
+ssh-keygen -t rsa  # Press Enter at the prompts
 # Download latest version of Vagrant (apt-get installs old version)
 wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
 sudo dpkg -i vagrant_1.8.1_x86_64.deb
 sudo apt-get install -f
 rm vagrant_1.8.1_x86_64.deb
-# Generate SSH key (for Vagrant to have SSH access to VM)
-mkdir -p $HOME/.ssh
-chmod 0700 $HOME/.ssh
-ssh-keygen -t rsa  # Press Enter at both prompts
 # Set up virtualenvwrapper
 printf '\n%s\n%s\n%s' '# virtualenv' 'export WORKON_HOME=~/virtualenvs' \
 'source /usr/local/bin/virtualenvwrapper.sh' >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ virtual environments using [virtualenv][4] and [virtualenvwrapper][5].
 
 ### Windows Users
 Ansible is used to provision the Vagrant VM, and since Windows machines
-<strike>cannot currently</strike> can be Ansible controllers [with some
+<strike>cannot currently</strike> can be Ansible controllers, [with some
 work][6] this <strike>will not</strike> should also work on Windows. A Unix
 machine (e.g. Linux, Mac OS X) is preferred since Ansible will be automatically
 installed into a virtualenv later and will work out of the box on Unix machines.

--- a/README.md
+++ b/README.md
@@ -33,11 +33,7 @@ quickly get all your requirements and set up virtualenvwrapper with:
 sudo apt-get update
 sudo apt-get install --upgrade python-pip python-dev build-essential virtualbox libpq-dev
 sudo pip install --upgrade pip virtualenv virtualenvwrapper
-# Generate SSH key (for Vagrant to have SSH access to VM)
-mkdir -p $HOME/.ssh
-chmod 0700 $HOME/.ssh
-ssh-keygen -t rsa  # Press Enter at the prompts
-# Download latest version of Vagrant (apt-get installs old version)
+# Install Vagrant (apt-get installs old version)
 wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
 sudo dpkg -i vagrant_1.8.1_x86_64.deb
 sudo apt-get install -f

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ source ~/.bashrc
 mkdir -p $WORKON_HOME
 ```
 
-[1]: (https://www.vagrantup.com/downloads.html)
-[2]: (https://www.virtualbox.org/wiki/Downloads)
-[3]: (https://pip.pypa.io/en/stable/installing/)
-[4]: (http://docs.python-guide.org/en/latest/dev/virtualenvs/)
-[5]: (http://virtualenvwrapper.readthedocs.org/en/latest/install.html)
-[6]: (http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/)
+[1]: https://www.vagrantup.com/downloads.html
+[2]: https://www.virtualbox.org/wiki/Downloads
+[3]: https://pip.pypa.io/en/stable/installing/
+[4]: http://docs.python-guide.org/en/latest/dev/virtualenvs/
+[5]: http://virtualenvwrapper.readthedocs.org/en/latest/install.html
+[6]: http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/
 
 System Requirements: 3GB RAM and 90GB Free HD Space.
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ installed into a virtualenv later and will work out of the box on Unix machines.
 
 ### Ubuntu Users
 
-On Ubuntu, if you are using the standard Terminal you can quickly get all
-your requirements and set up virtualenvwrapper with:
+On a fresh Ubuntu machine, if you are using the standard Terminal you can
+quickly get all your requirements and set up virtualenvwrapper with:
 
 ```bash
 sudo apt-get update
-sudo apt-get install python-pip python-dev build-essential virtualenv virtualenvwrapper vagrant virtualbox
-sudo apt-get install --upgrade pip
+sudo apt-get install --upgrade python-pip python-dev build-essential  virtualbox libpq-dev
+sudo pip install --upgrade pip virtualenv virtualenvwrapper
+# Download latest version of Vagrant (apt-get installs old version)
+wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
+sudo dpkg -i vagrant_1.8.1_x86_64.deb
+sudo apt-get install -f
+rm vagrant_1.8.1_x86_64.deb
 # Set up virtualenvwrapper
 printf '\n%s\n%s\n%s' '# virtualenv' 'export WORKON_HOME=~/virtualenvs' \
 'source /usr/local/bin/virtualenvwrapper.sh' >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
 sudo dpkg -i vagrant_1.8.1_x86_64.deb
 sudo apt-get install -f
 rm vagrant_1.8.1_x86_64.deb
+# Generate SSH key (for Vagrant to have SSH access to VM)
+mkdir -p $HOME/.ssh
+chmod 0700 $HOME/.ssh
+ssh-keygen -t rsa  # Press Enter at both prompts
 # Set up virtualenvwrapper
 printf '\n%s\n%s\n%s' '# virtualenv' 'export WORKON_HOME=~/virtualenvs' \
 'source /usr/local/bin/virtualenvwrapper.sh' >> ~/.bashrc


### PR DESCRIPTION
- [ ] Test that the supplied commands in the Readme truly work on Ubuntu

Updates included in PR:
- You mention using virtualenvwrapper but didn't provide a link to any
  installation instructions until now.
- Clarifies that Ansible doesn't need to be installed separately since
  it will be installed into a virtualenv.
- Adds quick list of commands to get requirements on Ubuntu (useful is someone is working via SSH).
- Fixes #2.
